### PR TITLE
Analogue Duo Support

### DIFF
--- a/AnalogueOSLibraryImageGenerator.ps1
+++ b/AnalogueOSLibraryImageGenerator.ps1
@@ -988,7 +988,7 @@ Function Convert-SingleImage {
         [Parameter(Mandatory)]
         [string]$OutFile,
         [Parameter(Mandatory)]
-        [ValidateSet('Original', 'BoxArts')]
+        [ValidateSet('Original', 'BoxArts', 'Titles')]
         [string]$ScaleMode,
         [byte[]]$ImageHeader
     )

--- a/AnalogueOSLibraryImageGenerator.ps1
+++ b/AnalogueOSLibraryImageGenerator.ps1
@@ -826,7 +826,7 @@ Function Convert-Images {
         [Parameter(Mandatory)]
         [hashtable[]]$Dat,
         [Parameter(Mandatory)]
-        [ValidateSet('Original', 'BoxArts')]
+        [ValidateSet('Original', 'BoxArts', 'Titles')]
         [string]$ScaleMode
     )
 
@@ -932,7 +932,6 @@ Function Convert-Images {
         # Determine outfile name (skip if game not found)
         $found = $false
         foreach ( $game in $Dat ) {
-
             # Per `libretro-thumbnails` instructions, replace the following characters
             # in the game name with an underscore, as these characters are illegal in
             # file paths:
@@ -940,9 +939,18 @@ Function Convert-Images {
             # &*/:`<>?\|"
             $useGameName = $game.name -replace '[&\*/:`<>\?\\\|"]', '_'
 
+            # The CRC of games containing multiple ROMs is the second track unless the game only has one.
+            $gameCrc = if ( $game.CRC -is [array] ) {
+                $index = [math]::Min($game.CRC.Count, 3) - 1
+                $game.CRC[$index]
+            }
+            else {
+                $game.CRC
+            }
+
             if ( $useBaseName -eq $useGameName ) {
                 $found = $true
-                $outFile = "$OutputDirectory\$($game.CRC).bin"
+                $outFile = "$OutputDirectory\$($gameCrc).bin"
 
                 $returnObj = Convert-ImageToAnalogueBmp -ScaleMode $ScaleMode $inFile $outFile -SourceFormat $imageType
                 $returnObj.Name = $_.BaseName


### PR DESCRIPTION
Fix #18 

Here's a quick summary of the changes:
- Added a new scaling option for Titles.
- Added logic to retrieve CRC for games that contain multiple ROMs.
- Refactored the logic to apply the scaling first (to make the scaling less confusing - inverting the width / height). 
- Fixed a bug when writing the headers for the image size (they were inverted).

Another thing we noticed during the testing was that the images don't appear to be rotated. I don't know if this is new for the upcoming OS 2.0 or if it was simply missed.

Prior to implementing the changes to the rotation logic, I wanted to check with you. How do you feel about adding a flag for the rotation? Another option would be to apply it based on the console, however, this doesn't feel great.

Either way, let me know what you think.